### PR TITLE
Fix output format and annotations

### DIFF
--- a/riff/riff.py
+++ b/riff/riff.py
@@ -40,7 +40,7 @@ def run_ruff(
             - stdout: The standard output (stdout) of the 'ruff' command as a string.
             - stderr: The standard error (stderr) of the 'ruff' command as a string.
     Raises:
-        ArgumentNotSupportedError: Raised if the `--format` argument is included in ruff_args.
+        ArgumentNotSupportedError: Raised if the `--output-format` argument is included in ruff_args.
 
     Note:
         If the `ruff` command exits with a non-zero status code, the returncode attribute
@@ -48,15 +48,15 @@ def run_ruff(
     """
     if not ruff_args:
         ruff_args = ["."]
-    elif "--format" in ruff_args:
-        logger.error("the `--format` argument is not (yet) supported")
+    elif "--output-format" in ruff_args:
+        logger.error("the `--output-format` argument is not (yet) supported")
         raise ArgumentNotSupportedError
 
     ruff_command = " ".join(
         (
             "ruff",
             *ruff_args,
-            "--format=json",
+            "--output-format=json",
         )
     ).rstrip()
     logger.debug(f"running '{ruff_command}'")

--- a/riff/riff.py
+++ b/riff/riff.py
@@ -130,7 +130,7 @@ def main(
 ) -> NoReturn:
     validate_repo_path()  # raises if a repo isn't found at cwd or above
     if not (modified_lines := parse_git_modified_lines(base_branch)):
-        raise typer.Exit(1)
+        raise typer.Exit(0)
 
     try:
         ruff_process_result = run_ruff(context.args)

--- a/riff/utils.py
+++ b/riff/utils.py
@@ -82,7 +82,7 @@ def parse_git_modified_lines(
             )
         )
     else:
-        logger.error(
+        logger.info(
             f"could not find any git-modified lines in {repo_root}: Are the files committed?"
         )
     return result

--- a/riff/utils.py
+++ b/riff/utils.py
@@ -82,7 +82,7 @@ def parse_git_modified_lines(
             )
         )
     else:
-        logger.info(
+        logger.warning(
             f"could not find any git-modified lines in {repo_root}: Are the files committed?"
         )
     return result

--- a/riff/violation.py
+++ b/riff/violation.py
@@ -31,12 +31,10 @@ class Violation(NamedTuple):
     column_end: int | None = None
 
     def to_github_annotation(self: "Violation") -> str:
-        endline = self.line_end if self.line_end is not None else self.line_start
-        suffix = f"\n{self.fix_suggestion}" if self.fix_suggestion else ""
-        return f"::error file={self.path},line={self.line_start},endline={endline},title={self.linter_name}:{self.error_code}{suffix}".replace(
-            "\n",
-            "%0A",  # GitHub annotations syntax
-        )
+        relativized_path = self.path.relative_to(Path.cwd())
+        first_part = f"::error title=Ruff ({self.error_code}),file={self.path},line={self.line_start},col={self.column_start},endLine={self.line_end},endColumn={self.column_end}::"
+        second_part = f"{relativized_path}:{self.line_start}:{self.column_start}: {self.error_code} {self.message}"
+        return first_part + second_part
 
     @staticmethod
     def parse(raw: dict) -> "Violation":


### PR DESCRIPTION
- Use the new `--output-format` flag instead of `--format`. The new version of `ruff` doesn't support `--format`
- Fix GitHub Actions annotations by using the same logic in Ruff:
https://github.com/astral-sh/ruff/blob/main/crates/ruff_linter/src/message/github.rs#L33-L52

Resolves #98 
Resolves #100 