### PR TITLE
fix false-negative when running with newer versions of ruff 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ lint.ignore = [
     "TRY003",
     "TD",
     "W293",
+    "EM101",
 ]
 target-version = "py310"
 line-length = 88

--- a/riff/riff.py
+++ b/riff/riff.py
@@ -20,7 +20,7 @@ app = typer.Typer(no_args_is_help=True, invoke_without_command=True)
 class ArgumentNotSupportedError(Exception): ...
 
 
-def run_ruff(ruff_args: Sequence[str]) -> subprocess.CompletedProcess:
+def run_ruff(ruff_args: list[str]) -> subprocess.CompletedProcess:
     """
     Run Ruff with the given arguments.
 
@@ -45,10 +45,14 @@ def run_ruff(ruff_args: Sequence[str]) -> subprocess.CompletedProcess:
         of the returned CompletedProcess object will reflect that status code.
     """
     if not ruff_args:
-        ruff_args = (".",)
+        logger.debug("No ruff arguments provided, using default: '.'")
+        ruff_args = ["."]
     elif "--output-format" in ruff_args:
         logger.error("the `--output-format` argument is not (yet) supported")
         raise ArgumentNotSupportedError
+    elif "check" in ruff_args:
+        logger.debug("Removing 'check' from ruff_args, it will be added later")
+        ruff_args.remove("check")
 
     ruff_command = " ".join(
         (

--- a/riff/riff.py
+++ b/riff/riff.py
@@ -168,9 +168,8 @@ def main(  # dead: disable
     except ArgumentNotSupportedError:
         raise typer.Exit(1) from None  # no need for whole stack trace
     if ruff_process_result.stderr:
-        raise RuntimeError(
-            f"Ruff failed running, stderr:\n{ruff_process_result.stderr}"
-        )
+        logger.error(f"Ruff failed running, stderr:\n{ruff_process_result.stderr}")
+        raise typer.Exit(1)
 
     if not (
         filtered_violations := filter_violations(

--- a/riff/riff.py
+++ b/riff/riff.py
@@ -1,5 +1,5 @@
 import subprocess
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 from pathlib import Path
 from typing import NoReturn
 

--- a/riff/utils.py
+++ b/riff/utils.py
@@ -11,12 +11,21 @@ from riff.logger import logger
 from riff.violation import Violation
 
 
-def parse_ruff_output(ruff_result_raw: str) -> tuple[Violation, ...]:
-    if not ruff_result_raw:
+def parse_ruff_output(ruff_stdout: str) -> tuple[Violation, ...]:
+    """
+    This method assumes stderr was empty
+    """
+    logger.debug(f"{ruff_stdout=}")
+
+    if not ruff_stdout:
+        logger.debug("No ruff output, assuming no violations")
         return ()
 
-    with logger.catch(json.JSONDecodeError, reraise=True):
-        raw_violations = json.loads(ruff_result_raw)
+    try:
+        raw_violations = json.loads(ruff_stdout)
+    except json.JSONDecodeError:
+        logger.exception("Could not parse Ruff output as JSON")
+        raise
 
     violations = tuple(map(Violation.parse, raw_violations))
     logger.debug(f"parsed {len(violations)} ruff violations")

--- a/riff/utils.py
+++ b/riff/utils.py
@@ -24,7 +24,7 @@ def parse_ruff_output(ruff_stdout: str) -> tuple[Violation, ...]:
     try:
         raw_violations = json.loads(ruff_stdout)
     except json.JSONDecodeError:
-        logger.error("Could not parse Ruff output as JSON:")
+        logger.error("Could not parse Ruff output as JSON")
         raise
 
     violations = tuple(map(Violation.parse, raw_violations))

--- a/riff/utils.py
+++ b/riff/utils.py
@@ -24,7 +24,7 @@ def parse_ruff_output(ruff_stdout: str) -> tuple[Violation, ...]:
     try:
         raw_violations = json.loads(ruff_stdout)
     except json.JSONDecodeError:
-        logger.exception("Could not parse Ruff output as JSON")
+        logger.error("Could not parse Ruff output as JSON:")
         raise
 
     violations = tuple(map(Violation.parse, raw_violations))


### PR DESCRIPTION
riff would pass when running ruff, if ruff it wrote to `stderr`.
Now, non-empty `stderr` causes riff to fail.

Also, added `check` to the args automatically (users providing it explicitly won't see an error)